### PR TITLE
Add an args variable to include optional flags to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LIBS=-lm
 #	$(CC) -c $(LIBS) -o $@ %.cc $(CFLAGS)
 
 wtfile: clean
-	$(CC) -std=c++11 -o wtfile wt_file_reader.cpp wt_file.cpp -I. $(LIBS)
+	$(CC) ${ARGS} -std=c++11 -o wtfile wt_file_reader.cpp wt_file.cpp -I. $(LIBS)
 
 
 .PHONY: clean


### PR DESCRIPTION
Primarily so you can add the `-g` flag to add debugging information to the executable file.

```
$ make ARGS="-g" wtfile
```